### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nnerdmann/netbox-agent/security/code-scanning/3](https://github.com/nnerdmann/netbox-agent/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the jobs in this workflow only need to check out code and run tests/linters, they only require read access to repository contents. The best way to do this is to add `permissions: { contents: read }` at the top level of the workflow file, just below the `name` field and before the `on` field. This will apply the restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
